### PR TITLE
Project: LCD_driver_interface change

### DIFF
--- a/examples/ATMEGA328P_ARDUINO_UNO_R3/src/LCD_IO_driver.c
+++ b/examples/ATMEGA328P_ARDUINO_UNO_R3/src/LCD_IO_driver.c
@@ -5,7 +5,7 @@
  * @Last Modified time: 2023-12-08 10:49:44
  */
 
-// #include "lcd_hd44780_config.h"
+
 #include "lcd_hd44780_interface.h"
 #include "lcd_hd44780_config.h"
 #include <stdio.h>
@@ -41,10 +41,10 @@ static void init_LCD_DATA_PINS_as_outputs(void);
 static void init_LCD_DATA_PINS_as_inputs(void);
 static void set_LCD_DATA_PINS_state(uint8_t data);
 static uint8_t get_LCD_DATA_PINS_state(void);
-static void init_LCD_SIGNAL_PINS_as_outputs(void);
 static void LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void LCD_reset_SIG(enum lcd_sig LCD_SIG);
 static void wraper_delay_us(uint32_t delay_us);
+static void init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
@@ -53,7 +53,6 @@ static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
     init_LCD_DATA_PINS_as_inputs,
     set_LCD_DATA_PINS_state,
     get_LCD_DATA_PINS_state,
-    init_LCD_SIGNAL_PINS_as_outputs,
     LCD_set_SIG,
     LCD_reset_SIG,
     wraper_delay_us,
@@ -125,16 +124,6 @@ static uint8_t get_LCD_DATA_PINS_state(void)
     return data;
 }
 
-static void init_LCD_SIGNAL_PINS_as_outputs(void)
-{
-#if USE_RW_PIN == ON
-    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_RW | LCD_PIN_E);
-
-#else
-    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_E);
-#endif
-}
-
 static void LCD_set_SIG(enum lcd_sig LCD_SIG)
 {
     switch (LCD_SIG)
@@ -175,7 +164,17 @@ static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
     }
 }
 
-void wraper_delay_us(uint32_t delay_us)
+static void wraper_delay_us(uint32_t delay_us)
 {
     _delay_us((double)(delay_us));
+}
+
+static void init_LCD_SIGNAL_PINS_as_outputs(void)
+{
+#if USE_RW_PIN == ON
+    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_RW | LCD_PIN_E);
+
+#else
+    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_E);
+#endif
 }

--- a/examples/STM32G071RB_NUCLEO_BARE_METAL/Core/Src/LCD_IO_driver.c
+++ b/examples/STM32G071RB_NUCLEO_BARE_METAL/Core/Src/LCD_IO_driver.c
@@ -78,9 +78,9 @@ static void set_LCD_DATA_PINS_as_outputs(void);
 static void set_LCD_DATA_PINS_as_inputs(void);
 static void set_LCD_DATA_PINS_state(uint8_t data);
 static uint8_t get_LCD_DATA_PINS_state(void);
-static void init_LCD_SIGNAL_PINS_as_outputs(void);
 static void LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void LCD_reset_SIG(enum lcd_sig LCD_SIG);
+static void init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
@@ -89,7 +89,6 @@ static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
     set_LCD_DATA_PINS_as_inputs,
     set_LCD_DATA_PINS_state,
     get_LCD_DATA_PINS_state,
-    init_LCD_SIGNAL_PINS_as_outputs,
     LCD_set_SIG,
     LCD_reset_SIG,
     _delay_us,
@@ -174,23 +173,6 @@ static uint8_t get_LCD_DATA_PINS_state(void)
     return data;
 }
 
-static void init_LCD_SIGNAL_PINS_as_outputs(void)
-{
-    RCC -> IOPENR |= LCD_RS_PORT_CLK_EN;
-    LCD_RS_PORT->MODER &=(~MODER_LCD_RS_Msk);
-    LCD_RS_PORT->MODER |= MODER_LCD_RS_0;
-
-    RCC -> IOPENR |= LCD_E_PORT_CLK_EN;
-    LCD_E_PORT->MODER &=(~MODER_LCD_E_Msk);
-    LCD_E_PORT->MODER |= MODER_LCD_E_0;
-
-#if USE_RW_PIN == 1
-    RCC -> IOPENR |= LCD_RW_PORT_CLK_EN;
-    LCD_RW_PORT->MODER &=(~MODER_LCD_RW_Msk);
-    LCD_RW_PORT->MODER |= MODER_LCD_RW_0;
-#endif
-}
-
 static void LCD_set_SIG(enum lcd_sig LCD_SIG)
 {
     switch (LCD_SIG)
@@ -229,4 +211,21 @@ static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
     default:
         break;
     }
+}
+
+static void init_LCD_SIGNAL_PINS_as_outputs(void)
+{
+    RCC -> IOPENR |= LCD_RS_PORT_CLK_EN;
+    LCD_RS_PORT->MODER &=(~MODER_LCD_RS_Msk);
+    LCD_RS_PORT->MODER |= MODER_LCD_RS_0;
+
+    RCC -> IOPENR |= LCD_E_PORT_CLK_EN;
+    LCD_E_PORT->MODER &=(~MODER_LCD_E_Msk);
+    LCD_E_PORT->MODER |= MODER_LCD_E_0;
+
+#if USE_RW_PIN == 1
+    RCC -> IOPENR |= LCD_RW_PORT_CLK_EN;
+    LCD_RW_PORT->MODER &=(~MODER_LCD_RW_Msk);
+    LCD_RW_PORT->MODER |= MODER_LCD_RW_0;
+#endif
 }

--- a/examples/STM32G474RE_NUCLEO_CUBE_IDE_LL/Core/Src/LCD_IO_driver.c
+++ b/examples/STM32G474RE_NUCLEO_CUBE_IDE_LL/Core/Src/LCD_IO_driver.c
@@ -1,6 +1,6 @@
 /*
- * @Author: lukasz.niewelt 
- * @Date: 2023-12-07 15:51:41 
+ * @Author: lukasz.niewelt
+ * @Date: 2023-12-07 15:51:41
  * @Last Modified by: lukasz.niewelt
  * @Last Modified time: 2023-12-08 00:34:48
  */
@@ -13,7 +13,7 @@
 #define LCD_D6_MASK 0x04
 #define LCD_D7_MASK 0x08
 
-#define ON  1
+#define ON 1
 #define OFF 0
 
 // #include "lcd_hd44780_config.h"
@@ -30,167 +30,161 @@ static void set_LCD_DATA_PINS_as_outputs(void);
 static void set_LCD_DATA_PINS_as_inputs(void);
 static void set_LCD_DATA_PINS_state(uint8_t data);
 static uint8_t get_LCD_DATA_PINS_state(void);
-static void init_LCD_SIGNAL_PINS_as_outputs(void);
 static void LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void LCD_reset_SIG(enum lcd_sig LCD_SIG);
+static void init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
-   init_LCD_data_and_SIG_pins,
-   set_LCD_DATA_PINS_as_outputs,
-   set_LCD_DATA_PINS_as_inputs,
-   set_LCD_DATA_PINS_state,
-   get_LCD_DATA_PINS_state,
-   init_LCD_SIGNAL_PINS_as_outputs,
-   LCD_set_SIG,
-   LCD_reset_SIG,
-   _delay_us,
+    init_LCD_data_and_SIG_pins,
+    set_LCD_DATA_PINS_as_outputs,
+    set_LCD_DATA_PINS_as_inputs,
+    set_LCD_DATA_PINS_state,
+    get_LCD_DATA_PINS_state,
+    LCD_set_SIG,
+    LCD_reset_SIG,
+    _delay_us,
 };
 const struct LCD_IO_driver_interface_struct *LCD_IO_driver_interface_get(void)
 {
-   return &LCD_IO_driver;
+    return &LCD_IO_driver;
 }
 
 /*************LCD_IO_driver_interface implementation END***************/
 
 static void init_LCD_data_and_SIG_pins(void)
 {
-   //all pins was initialized in CubeIDE code
-//    LL_GPIO_ResetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
-
+    // all pins was initialized in CubeIDE code
+    //    LL_GPIO_ResetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
 }
 
 static void set_LCD_DATA_PINS_as_outputs(void)
 {
 
-   GPIO_InitStruct.Pin = LCD_D6_Pin | LCD_D5_Pin | LCD_D4_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-   GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-   GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-   LL_GPIO_Init(LCD_DATA_PORTB, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LCD_D6_Pin | LCD_D5_Pin | LCD_D4_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_DATA_PORTB, &GPIO_InitStruct);
 
-   GPIO_InitStruct.Pin = LCD_D7_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-   GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-   GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-   LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
-
+    GPIO_InitStruct.Pin = LCD_D7_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
 }
 static void set_LCD_DATA_PINS_as_inputs(void)
 {
-   GPIO_InitStruct.Pin = LCD_D6_Pin | LCD_D5_Pin | LCD_D4_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
-   LL_GPIO_Init(LCD_DATA_PORTB, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LCD_D6_Pin | LCD_D5_Pin | LCD_D4_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
+    LL_GPIO_Init(LCD_DATA_PORTB, &GPIO_InitStruct);
 
-   GPIO_InitStruct.Pin = LCD_D7_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
-   LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
-
+    GPIO_InitStruct.Pin = LCD_D7_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
+    LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
 }
 
 static void set_LCD_DATA_PINS_state(uint8_t data)
 {
-   if ((data & LCD_D4_MASK))
-       LL_GPIO_SetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
-   else
-       LL_GPIO_ResetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
+    if ((data & LCD_D4_MASK))
+        LL_GPIO_SetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
+    else
+        LL_GPIO_ResetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
 
-   if ((data & LCD_D5_MASK))
-       LL_GPIO_SetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
-   else
-       LL_GPIO_ResetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
+    if ((data & LCD_D5_MASK))
+        LL_GPIO_SetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
+    else
+        LL_GPIO_ResetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
 
-   if ((data & LCD_D6_MASK))
-       LL_GPIO_SetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
-   else
-       LL_GPIO_ResetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
-   if ((data & LCD_D7_MASK))
-       LL_GPIO_SetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
-   else
-       LL_GPIO_ResetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
+    if ((data & LCD_D6_MASK))
+        LL_GPIO_SetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
+    else
+        LL_GPIO_ResetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
+    if ((data & LCD_D7_MASK))
+        LL_GPIO_SetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
+    else
+        LL_GPIO_ResetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
 }
 
 static uint8_t get_LCD_DATA_PINS_state(void)
 {
-   uint8_t data = 0;
-   if (LL_GPIO_IsInputPinSet(LCD_D4_GPIO_Port, LCD_D4_Pin))
-       data = LCD_D4_MASK;
-   if (LL_GPIO_IsInputPinSet(LCD_D5_GPIO_Port, LCD_D5_Pin))
-       data |= LCD_D5_MASK;
-   if (LL_GPIO_IsInputPinSet(LCD_D6_GPIO_Port, LCD_D6_Pin))
-       data |= LCD_D6_MASK;
-   if (LL_GPIO_IsInputPinSet(LCD_D7_GPIO_Port, LCD_D7_Pin))
-       data |= LCD_D7_MASK;
-   return data;
+    uint8_t data = 0;
+    if (LL_GPIO_IsInputPinSet(LCD_D4_GPIO_Port, LCD_D4_Pin))
+        data = LCD_D4_MASK;
+    if (LL_GPIO_IsInputPinSet(LCD_D5_GPIO_Port, LCD_D5_Pin))
+        data |= LCD_D5_MASK;
+    if (LL_GPIO_IsInputPinSet(LCD_D6_GPIO_Port, LCD_D6_Pin))
+        data |= LCD_D6_MASK;
+    if (LL_GPIO_IsInputPinSet(LCD_D7_GPIO_Port, LCD_D7_Pin))
+        data |= LCD_D7_MASK;
+    return data;
+}
 
+static void LCD_set_SIG(enum lcd_sig LCD_SIG)
+{
+    switch (LCD_SIG)
+    {
+    case LCD_RS:
+        LL_GPIO_SetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
+        break;
+    case LCD_E:
+        LL_GPIO_SetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
+        break;
+#if USE_RW_PIN == ON
+    case LCD_RW:
+        LL_GPIO_SetOutputPin(LCD_RW_GPIO_Port, LCD_RW_Pin);
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
+{
+    switch (LCD_SIG)
+    {
+    case LCD_RS:
+        LL_GPIO_ResetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
+        break;
+    case LCD_E:
+        LL_GPIO_ResetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
+        break;
+#if USE_RW_PIN == ON
+    case LCD_RW:
+        LL_GPIO_ResetOutputPin(LCD_RW_GPIO_Port, LCD_RW_Pin);
+        break;
+#endif
+    default:
+        break;
+    }
 }
 
 static void init_LCD_SIGNAL_PINS_as_outputs(void)
 {
 #if USE_RW_PIN == ON
-   GPIO_InitStruct.Pin = LCD_RW_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-   GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-   GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-   LL_GPIO_Init(LCD_RW_GPIO_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LCD_RW_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_RW_GPIO_Port, &GPIO_InitStruct);
 #endif
-   GPIO_InitStruct.Pin = LCD_RS_Pin ;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-   GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-   GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-   LL_GPIO_Init(LCD_RS_GPIO_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LCD_RS_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_RS_GPIO_Port, &GPIO_InitStruct);
 
-   GPIO_InitStruct.Pin = LCD_E_Pin;
-   GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-   GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-   GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-   GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-   LL_GPIO_Init(LCD_E_GPIO_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LCD_E_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_E_GPIO_Port, &GPIO_InitStruct);
 }
-
-static void LCD_set_SIG(enum lcd_sig LCD_SIG)
-{
-   switch (LCD_SIG)
-   {
-   case LCD_RS:
-       LL_GPIO_SetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
-       break;
-   case LCD_E:
-       LL_GPIO_SetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
-       break;
-#if USE_RW_PIN == ON
-   case LCD_RW:
-       LL_GPIO_SetOutputPin(LCD_RW_GPIO_Port, LCD_RW_Pin);
-       break;
-#endif
-   default:
-       break;
-   }
-}
-
-static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
-{
-   switch (LCD_SIG)
-   {
-   case LCD_RS:
-       LL_GPIO_ResetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
-       break;
-   case LCD_E:
-       LL_GPIO_ResetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
-       break;
-#if USE_RW_PIN == ON
-   case LCD_RW:
-       LL_GPIO_ResetOutputPin(LCD_RW_GPIO_Port, LCD_RW_Pin);
-       break;
-#endif
-   default:
-       break;
-   }
-}
-

--- a/examples/STM32G474RE_NUCLEO_CUBE_IDE_LL/Core/Src/main.c
+++ b/examples/STM32G474RE_NUCLEO_CUBE_IDE_LL/Core/Src/main.c
@@ -1,20 +1,20 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file           : main.c
-  * @brief          : Main program body
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2024 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file           : main.c
+ * @brief          : Main program body
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2024 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
@@ -67,381 +67,381 @@ static void lcd_buf_slide_str_out(const char *str, enum LCD_LINES lcd_line, uint
 /* USER CODE END 0 */
 
 /**
-  * @brief  The application entry point.
-  * @retval int
-  */
+ * @brief  The application entry point.
+ * @retval int
+ */
 int main(void)
 {
-  /* USER CODE BEGIN 1 */
+    /* USER CODE BEGIN 1 */
 
-  /* USER CODE END 1 */
+    /* USER CODE END 1 */
 
-  /* MCU Configuration--------------------------------------------------------*/
+    /* MCU Configuration--------------------------------------------------------*/
 
-  /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
-  LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
-  LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+    /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 
-  /* System interrupt init*/
-  NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+    /* System interrupt init*/
+    NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
-  /** Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral
-  */
-  LL_PWR_DisableUCPDDeadBattery();
+    /** Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral
+     */
+    LL_PWR_DisableUCPDDeadBattery();
 
-  /* USER CODE BEGIN Init */
+    /* USER CODE BEGIN Init */
 
-  /* USER CODE END Init */
+    /* USER CODE END Init */
 
-  /* Configure the system clock */
-  SystemClock_Config();
+    /* Configure the system clock */
+    SystemClock_Config();
 
-  /* USER CODE BEGIN SysInit */
+    /* USER CODE BEGIN SysInit */
 
-  /* USER CODE END SysInit */
+    /* USER CODE END SysInit */
 
-  /* Initialize all configured peripherals */
-  MX_GPIO_Init();
-  MX_LPUART1_UART_Init();
-  /* USER CODE BEGIN 2 */
-  // LL_GPIO_ResetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
-  // _delay_ms(1000);
-  // LL_GPIO_SetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
-  lcd_init();
-  lcd_buf_str(demo_title);
-  lcd_update();
-  /* USER CODE END 2 */
+    /* Initialize all configured peripherals */
+    MX_GPIO_Init();
+    MX_LPUART1_UART_Init();
+    /* USER CODE BEGIN 2 */
+    // LL_GPIO_ResetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
+    // _delay_ms(1000);
+    // LL_GPIO_SetOutputPin(LCD_BCKL_GPIO_Port,LCD_BCKL_Pin);
+    lcd_init();
+    lcd_buf_str(demo_title);
+    lcd_update();
+    /* USER CODE END 2 */
 
-  /* Infinite loop */
-  /* USER CODE BEGIN WHILE */
-  while (1)
-  {
-    lcd_buf_slide_str_in(demo_tekst, LINE_2, SHIFT_DELAY);
-    lcd_buf_slide_str_out(demo_tekst, LINE_2, SHIFT_DELAY);
-    /* USER CODE END WHILE */
+    /* Infinite loop */
+    /* USER CODE BEGIN WHILE */
+    while (1)
+    {
+        lcd_buf_slide_str_in(demo_tekst, LINE_2, SHIFT_DELAY);
+        lcd_buf_slide_str_out(demo_tekst, LINE_2, SHIFT_DELAY);
+        /* USER CODE END WHILE */
 
-    /* USER CODE BEGIN 3 */
-  }
-  /* USER CODE END 3 */
+        /* USER CODE BEGIN 3 */
+    }
+    /* USER CODE END 3 */
 }
 
 /**
-  * @brief System Clock Configuration
-  * @retval None
-  */
+ * @brief System Clock Configuration
+ * @retval None
+ */
 void SystemClock_Config(void)
 {
-  LL_FLASH_SetLatency(LL_FLASH_LATENCY_3);
-  while(LL_FLASH_GetLatency() != LL_FLASH_LATENCY_3)
-  {
-  }
-  LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
-  LL_RCC_HSI_Enable();
-   /* Wait till HSI is ready */
-  while(LL_RCC_HSI_IsReady() != 1)
-  {
-  }
+    LL_FLASH_SetLatency(LL_FLASH_LATENCY_3);
+    while (LL_FLASH_GetLatency() != LL_FLASH_LATENCY_3)
+    {
+    }
+    LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+    LL_RCC_HSI_Enable();
+    /* Wait till HSI is ready */
+    while (LL_RCC_HSI_IsReady() != 1)
+    {
+    }
 
-  LL_RCC_HSI_SetCalibTrimming(64);
-  LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSI, LL_RCC_PLLM_DIV_1, 12, LL_RCC_PLLR_DIV_2);
-  LL_RCC_PLL_EnableDomain_SYS();
-  LL_RCC_PLL_Enable();
-   /* Wait till PLL is ready */
-  while(LL_RCC_PLL_IsReady() != 1)
-  {
-  }
+    LL_RCC_HSI_SetCalibTrimming(64);
+    LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSI, LL_RCC_PLLM_DIV_1, 12, LL_RCC_PLLR_DIV_2);
+    LL_RCC_PLL_EnableDomain_SYS();
+    LL_RCC_PLL_Enable();
+    /* Wait till PLL is ready */
+    while (LL_RCC_PLL_IsReady() != 1)
+    {
+    }
 
-  LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
-  LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
-   /* Wait till System clock is ready */
-  while(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL)
-  {
-  }
+    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
+    LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_2);
+    /* Wait till System clock is ready */
+    while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL)
+    {
+    }
 
-  /* Insure 1us transition state at intermediate medium speed clock*/
-  for (__IO uint32_t i = (170 >> 1); i !=0; i--);
+    /* Insure 1us transition state at intermediate medium speed clock*/
+    for (__IO uint32_t i = (170 >> 1); i != 0; i--)
+        ;
 
-  /* Set AHB prescaler*/
-  LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
-  LL_RCC_SetAPB1Prescaler(LL_RCC_APB1_DIV_4);
-  LL_RCC_SetAPB2Prescaler(LL_RCC_APB2_DIV_1);
+    /* Set AHB prescaler*/
+    LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
+    LL_RCC_SetAPB1Prescaler(LL_RCC_APB1_DIV_4);
+    LL_RCC_SetAPB2Prescaler(LL_RCC_APB2_DIV_1);
 
-  LL_Init1msTick(96000000);
+    LL_Init1msTick(96000000);
 
-  LL_SetSystemCoreClock(96000000);
+    LL_SetSystemCoreClock(96000000);
 }
 
 /**
-  * @brief LPUART1 Initialization Function
-  * @param None
-  * @retval None
-  */
+ * @brief LPUART1 Initialization Function
+ * @param None
+ * @retval None
+ */
 static void MX_LPUART1_UART_Init(void)
 {
 
-  /* USER CODE BEGIN LPUART1_Init 0 */
+    /* USER CODE BEGIN LPUART1_Init 0 */
 
-  /* USER CODE END LPUART1_Init 0 */
+    /* USER CODE END LPUART1_Init 0 */
 
-  LL_LPUART_InitTypeDef LPUART_InitStruct = {0};
+    LL_LPUART_InitTypeDef LPUART_InitStruct = {0};
 
-  LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
+    LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
 
-  LL_RCC_SetLPUARTClockSource(LL_RCC_LPUART1_CLKSOURCE_PCLK1);
+    LL_RCC_SetLPUARTClockSource(LL_RCC_LPUART1_CLKSOURCE_PCLK1);
 
-  /* Peripheral clock enable */
-  LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_LPUART1);
+    /* Peripheral clock enable */
+    LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_LPUART1);
 
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
-  /**LPUART1 GPIO Configuration
-  PA2   ------> LPUART1_TX
-  PA3   ------> LPUART1_RX
-  */
-  GPIO_InitStruct.Pin = LPUART1_TX_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  GPIO_InitStruct.Alternate = LL_GPIO_AF_12;
-  LL_GPIO_Init(LPUART1_TX_GPIO_Port, &GPIO_InitStruct);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
+    /**LPUART1 GPIO Configuration
+    PA2   ------> LPUART1_TX
+    PA3   ------> LPUART1_RX
+    */
+    GPIO_InitStruct.Pin = LPUART1_TX_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    GPIO_InitStruct.Alternate = LL_GPIO_AF_12;
+    LL_GPIO_Init(LPUART1_TX_GPIO_Port, &GPIO_InitStruct);
 
-  GPIO_InitStruct.Pin = LPUART1_RX_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  GPIO_InitStruct.Alternate = LL_GPIO_AF_12;
-  LL_GPIO_Init(LPUART1_RX_GPIO_Port, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = LPUART1_RX_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    GPIO_InitStruct.Alternate = LL_GPIO_AF_12;
+    LL_GPIO_Init(LPUART1_RX_GPIO_Port, &GPIO_InitStruct);
 
-  /* USER CODE BEGIN LPUART1_Init 1 */
+    /* USER CODE BEGIN LPUART1_Init 1 */
 
-  /* USER CODE END LPUART1_Init 1 */
-  LPUART_InitStruct.PrescalerValue = LL_LPUART_PRESCALER_DIV1;
-  LPUART_InitStruct.BaudRate = 115200;
-  LPUART_InitStruct.DataWidth = LL_LPUART_DATAWIDTH_8B;
-  LPUART_InitStruct.StopBits = LL_LPUART_STOPBITS_1;
-  LPUART_InitStruct.Parity = LL_LPUART_PARITY_NONE;
-  LPUART_InitStruct.TransferDirection = LL_LPUART_DIRECTION_TX_RX;
-  LPUART_InitStruct.HardwareFlowControl = LL_LPUART_HWCONTROL_NONE;
-  LL_LPUART_Init(LPUART1, &LPUART_InitStruct);
-  LL_LPUART_SetTXFIFOThreshold(LPUART1, LL_LPUART_FIFOTHRESHOLD_1_8);
-  LL_LPUART_SetRXFIFOThreshold(LPUART1, LL_LPUART_FIFOTHRESHOLD_1_8);
-  LL_LPUART_DisableFIFO(LPUART1);
+    /* USER CODE END LPUART1_Init 1 */
+    LPUART_InitStruct.PrescalerValue = LL_LPUART_PRESCALER_DIV1;
+    LPUART_InitStruct.BaudRate = 115200;
+    LPUART_InitStruct.DataWidth = LL_LPUART_DATAWIDTH_8B;
+    LPUART_InitStruct.StopBits = LL_LPUART_STOPBITS_1;
+    LPUART_InitStruct.Parity = LL_LPUART_PARITY_NONE;
+    LPUART_InitStruct.TransferDirection = LL_LPUART_DIRECTION_TX_RX;
+    LPUART_InitStruct.HardwareFlowControl = LL_LPUART_HWCONTROL_NONE;
+    LL_LPUART_Init(LPUART1, &LPUART_InitStruct);
+    LL_LPUART_SetTXFIFOThreshold(LPUART1, LL_LPUART_FIFOTHRESHOLD_1_8);
+    LL_LPUART_SetRXFIFOThreshold(LPUART1, LL_LPUART_FIFOTHRESHOLD_1_8);
+    LL_LPUART_DisableFIFO(LPUART1);
 
-  /* USER CODE BEGIN WKUPType LPUART1 */
+    /* USER CODE BEGIN WKUPType LPUART1 */
 
-  /* USER CODE END WKUPType LPUART1 */
+    /* USER CODE END WKUPType LPUART1 */
 
-  LL_LPUART_Enable(LPUART1);
+    LL_LPUART_Enable(LPUART1);
 
-  /* Polling LPUART1 initialisation */
-  while((!(LL_LPUART_IsActiveFlag_TEACK(LPUART1))) || (!(LL_LPUART_IsActiveFlag_REACK(LPUART1))))
-  {
-  }
-  /* USER CODE BEGIN LPUART1_Init 2 */
+    /* Polling LPUART1 initialisation */
+    while ((!(LL_LPUART_IsActiveFlag_TEACK(LPUART1))) || (!(LL_LPUART_IsActiveFlag_REACK(LPUART1))))
+    {
+    }
+    /* USER CODE BEGIN LPUART1_Init 2 */
 
-  /* USER CODE END LPUART1_Init 2 */
-
+    /* USER CODE END LPUART1_Init 2 */
 }
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
 static void MX_GPIO_Init(void)
 {
-  LL_EXTI_InitTypeDef EXTI_InitStruct = {0};
-  LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
-/* USER CODE BEGIN MX_GPIO_Init_1 */
-/* USER CODE END MX_GPIO_Init_1 */
+    LL_EXTI_InitTypeDef EXTI_InitStruct = {0};
+    LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
+    /* USER CODE BEGIN MX_GPIO_Init_1 */
+    /* USER CODE END MX_GPIO_Init_1 */
 
-  /* GPIO Ports Clock Enable */
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOF);
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
+    /* GPIO Ports Clock Enable */
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOF);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LD2_GPIO_Port, LD2_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LD2_GPIO_Port, LD2_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_D6_GPIO_Port, LCD_D6_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_E_GPIO_Port, LCD_E_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_D7_GPIO_Port, LCD_D7_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_RS_GPIO_Port, LCD_RS_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_D5_GPIO_Port, LCD_D5_Pin);
 
-  /**/
-  LL_GPIO_ResetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
+    /**/
+    LL_GPIO_ResetOutputPin(LCD_D4_GPIO_Port, LCD_D4_Pin);
 
-  /**/
-  LL_GPIO_SetOutputPin(LCD_BCKL_GPIO_Port, LCD_BCKL_Pin);
+    /**/
+    LL_GPIO_SetOutputPin(LCD_BCKL_GPIO_Port, LCD_BCKL_Pin);
 
-  /**/
-  LL_SYSCFG_SetEXTISource(LL_SYSCFG_EXTI_PORTC, LL_SYSCFG_EXTI_LINE13);
+    /**/
+    LL_SYSCFG_SetEXTISource(LL_SYSCFG_EXTI_PORTC, LL_SYSCFG_EXTI_LINE13);
 
-  /**/
-  EXTI_InitStruct.Line_0_31 = LL_EXTI_LINE_13;
-  EXTI_InitStruct.LineCommand = ENABLE;
-  EXTI_InitStruct.Mode = LL_EXTI_MODE_IT;
-  EXTI_InitStruct.Trigger = LL_EXTI_TRIGGER_RISING;
-  LL_EXTI_Init(&EXTI_InitStruct);
+    /**/
+    EXTI_InitStruct.Line_0_31 = LL_EXTI_LINE_13;
+    EXTI_InitStruct.LineCommand = ENABLE;
+    EXTI_InitStruct.Mode = LL_EXTI_MODE_IT;
+    EXTI_InitStruct.Trigger = LL_EXTI_TRIGGER_RISING;
+    LL_EXTI_Init(&EXTI_InitStruct);
 
-  /**/
-  LL_GPIO_SetPinPull(B1_GPIO_Port, B1_Pin, LL_GPIO_PULL_NO);
+    /**/
+    LL_GPIO_SetPinPull(B1_GPIO_Port, B1_Pin, LL_GPIO_PULL_NO);
 
-  /**/
-  LL_GPIO_SetPinMode(B1_GPIO_Port, B1_Pin, LL_GPIO_MODE_INPUT);
+    /**/
+    LL_GPIO_SetPinMode(B1_GPIO_Port, B1_Pin, LL_GPIO_MODE_INPUT);
 
-  /**/
-  GPIO_InitStruct.Pin = LD2_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LD2_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LD2_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LD2_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_D6_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_D6_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_D6_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_D6_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_E_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_E_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_E_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_E_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_D7_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_D7_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_D7_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_RS_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_RS_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_RS_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_RS_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_D5_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_D5_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_D5_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_D5_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_D4_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_D4_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_D4_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_D4_GPIO_Port, &GPIO_InitStruct);
 
-  /**/
-  GPIO_InitStruct.Pin = LCD_BCKL_Pin;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(LCD_BCKL_GPIO_Port, &GPIO_InitStruct);
+    /**/
+    GPIO_InitStruct.Pin = LCD_BCKL_Pin;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    LL_GPIO_Init(LCD_BCKL_GPIO_Port, &GPIO_InitStruct);
 
-  /* EXTI interrupt init*/
-  NVIC_SetPriority(EXTI15_10_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(),0, 0));
-  NVIC_EnableIRQ(EXTI15_10_IRQn);
+    /* EXTI interrupt init*/
+    NVIC_SetPriority(EXTI15_10_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 0, 0));
+    NVIC_EnableIRQ(EXTI15_10_IRQn);
 
-/* USER CODE BEGIN MX_GPIO_Init_2 */
-/* USER CODE END MX_GPIO_Init_2 */
+    /* USER CODE BEGIN MX_GPIO_Init_2 */
+    /* USER CODE END MX_GPIO_Init_2 */
 }
 
 /* USER CODE BEGIN 4 */
 void lcd_buf_slide_str_out(const char *str, enum LCD_LINES lcd_line, uint16_t speed)
 {
-   uint8_t str_end_flag = 0;
-   for (j = 0; j <= strlen(str); j++)
-   {
-       _delay_ms(speed);
-       lcd_buf_locate(lcd_line, C1);
-       for (i = 0; i < LCD_X; i++)
-       {
-           if ((str[j + i] != '\0') && (str_end_flag == 0))
-           {
-               lcd_buf_char(str[j + i]);
-           }
-           else
-           {
-               str_end_flag = 0xFF;
-               lcd_buf_char(' ');
-           }
-       }
-       str_end_flag = 0;
-       lcd_update();
-   }
+    uint8_t str_end_flag = 0;
+    for (j = 0; j <= strlen(str); j++)
+    {
+        _delay_ms(speed);
+        lcd_buf_locate(lcd_line, C1);
+        for (i = 0; i < LCD_X; i++)
+        {
+            if ((str[j + i] != '\0') && (str_end_flag == 0))
+            {
+                lcd_buf_char(str[j + i]);
+            }
+            else
+            {
+                str_end_flag = 0xFF;
+                lcd_buf_char(' ');
+            }
+        }
+        str_end_flag = 0;
+        lcd_update();
+    }
 }
 
 void lcd_buf_slide_str_in(const char *str, enum LCD_LINES lcd_line, uint16_t speed)
 {
-   for (i = LCD_X - 1; i > C1; i--)
-   {
-       _delay_ms(speed);
-       lcd_buf_locate(lcd_line, i);
-       for (uint8_t j = 0; j < (LCD_X - i); j++)
-       {
-           lcd_buf_char(str[j]);
-       }
-       lcd_update();
-   }
+    for (i = LCD_X - 1; i > C1; i--)
+    {
+        _delay_ms(speed);
+        lcd_buf_locate(lcd_line, i);
+        for (uint8_t j = 0; j < (LCD_X - i); j++)
+        {
+            lcd_buf_char(str[j]);
+        }
+        lcd_update();
+    }
 }
 /* USER CODE END 4 */
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @retval None
-  */
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
 void Error_Handler(void)
 {
-  /* USER CODE BEGIN Error_Handler_Debug */
-  /* User can add his own implementation to report the HAL error return state */
-  __disable_irq();
-  while (1)
-  {
-  }
-  /* USER CODE END Error_Handler_Debug */
+    /* USER CODE BEGIN Error_Handler_Debug */
+    /* User can add his own implementation to report the HAL error return state */
+    __disable_irq();
+    while (1)
+    {
+    }
+    /* USER CODE END Error_Handler_Debug */
 }
 
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
-  * @brief  Reports the name of the source file and the source line number
-  *         where the assert_param error has occurred.
-  * @param  file: pointer to the source file name
-  * @param  line: assert_param error line source number
-  * @retval None
-  */
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
 void assert_failed(uint8_t *file, uint32_t line)
 {
-  /* USER CODE BEGIN 6 */
-  /* User can add his own implementation to report the file name and line number,
-     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-  /* USER CODE END 6 */
+    /* USER CODE BEGIN 6 */
+    /* User can add his own implementation to report the file name and line number,
+       ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+    /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */

--- a/src/lcd_hd44780_interface.h
+++ b/src/lcd_hd44780_interface.h
@@ -25,7 +25,7 @@ extern "C"
     typedef void (*set_LCD_data_pins_as_inputs_func_p)(void);
     typedef void (*set_LCD_data_port_func_p)(uint8_t data);
     typedef uint8_t (*get_LCD_data_port_func_p)(void);
-    typedef void (*init_LCD_SIG_func_p)(void);
+    // typedef void (*init_LCD_SIG_func_p)(void);
     typedef void (*set_LCD_SIG_func_p)(enum lcd_sig LCD_SIG);
     typedef void (*reset_LCD_SIG_func_p)(enum lcd_sig LCD_SIG);
     typedef void (*delay_us_func_p)(uint32_t delay_us);
@@ -37,7 +37,7 @@ extern "C"
         set_LCD_data_pins_as_inputs_func_p set_data_pins_as_inputs;
         set_LCD_data_port_func_p write_data;
         get_LCD_data_port_func_p read_data;
-        init_LCD_SIG_func_p init_SIG;
+        // init_LCD_SIG_func_p init_SIG;
         set_LCD_SIG_func_p set_SIG;
         reset_LCD_SIG_func_p reset_SIG;
         delay_us_func_p delay_us;

--- a/test/hw_test/ATMEGA328P_ARDUINO_UNO_R3/src/LCD_IO_driver.c
+++ b/test/hw_test/ATMEGA328P_ARDUINO_UNO_R3/src/LCD_IO_driver.c
@@ -1,11 +1,10 @@
 /*
- * @Author: lukasz.niewelt 
- * @Date: 2023-12-04 20:13:23 
+ * @Author: lukasz.niewelt
+ * @Date: 2023-12-04 20:13:23
  * @Last Modified by: lukasz.niewelt
  * @Last Modified time: 2023-12-08 10:49:44
  */
 
-// #include "lcd_hd44780_config.h"
 #include "lcd_hd44780_interface.h"
 #include "lcd_hd44780_config.h"
 #include <stdio.h>
@@ -41,10 +40,10 @@ static void init_LCD_DATA_PINS_as_outputs(void);
 static void init_LCD_DATA_PINS_as_inputs(void);
 static void set_LCD_DATA_PINS_state(uint8_t data);
 static uint8_t get_LCD_DATA_PINS_state(void);
-static void init_LCD_SIGNAL_PINS_as_outputs(void);
 static void LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void LCD_reset_SIG(enum lcd_sig LCD_SIG);
 static void wraper_delay_us(uint32_t delay_us);
+static void init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
@@ -53,7 +52,6 @@ static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
     init_LCD_DATA_PINS_as_inputs,
     set_LCD_DATA_PINS_state,
     get_LCD_DATA_PINS_state,
-    init_LCD_SIGNAL_PINS_as_outputs,
     LCD_set_SIG,
     LCD_reset_SIG,
     wraper_delay_us,
@@ -67,22 +65,22 @@ const struct LCD_IO_driver_interface_struct *LCD_IO_driver_interface_get(void)
 
 static void init_LCD_data_and_SIG_pins(void)
 {
-    //set BCKL PIN as output
+    // set BCKL PIN as output
     LCD_BCKL_PORT_DIR |= LCD_BCKL_PIN;
-    //enable Backlight of the LCD
+    // enable Backlight of the LCD
     LCD_BCKL_PORT |= LCD_BCKL_PIN;
     init_LCD_DATA_PINS_as_outputs();
     init_LCD_SIGNAL_PINS_as_outputs();
 }
 static void init_LCD_DATA_PINS_as_outputs(void)
 {
-    //set pins as output
+    // set pins as output
     LCD_DATA_PORT_DIR |= (LCD_PIN_D4 | LCD_PIN_D5 | LCD_PIN_D6 | LCD_PIN_D7);
 }
 static void init_LCD_DATA_PINS_as_inputs(void)
 {
 
-    //set pins as inputs
+    // set pins as inputs
     LCD_DATA_PORT_DIR &= ~(LCD_PIN_D4 | LCD_PIN_D5 | LCD_PIN_D6 | LCD_PIN_D7);
     // enable pull-up on input pins
     LCD_DATA_PORT |= (LCD_PIN_D4 | LCD_PIN_D5 | LCD_PIN_D6 | LCD_PIN_D7);
@@ -125,16 +123,6 @@ static uint8_t get_LCD_DATA_PINS_state(void)
     return data;
 }
 
-static void init_LCD_SIGNAL_PINS_as_outputs(void)
-{
-#if USE_RW_PIN == ON
-    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_RW | LCD_PIN_E);
-
-#else
-    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_E);
-#endif
-}
-
 static void LCD_set_SIG(enum lcd_sig LCD_SIG)
 {
     switch (LCD_SIG)
@@ -175,7 +163,17 @@ static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
     }
 }
 
-void wraper_delay_us(uint32_t delay_us)
+static void wraper_delay_us(uint32_t delay_us)
 {
     _delay_us((double)(delay_us));
+}
+
+static void init_LCD_SIGNAL_PINS_as_outputs(void)
+{
+#if USE_RW_PIN == ON
+    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_RW | LCD_PIN_E);
+
+#else
+    LCD_SIG_PORT_DIR |= (LCD_PIN_RS | LCD_PIN_E);
+#endif
 }

--- a/test/hw_test/STM32F030R8_CUBE_IDE/Core/Src/LCD_IO_driver.c
+++ b/test/hw_test/STM32F030R8_CUBE_IDE/Core/Src/LCD_IO_driver.c
@@ -1,6 +1,6 @@
 /*
- * @Author: lukasz.niewelt 
- * @Date: 2023-12-07 15:51:41 
+ * @Author: lukasz.niewelt
+ * @Date: 2023-12-07 15:51:41
  * @Last Modified by: lukasz.niewelt
  * @Last Modified time: 2023-12-08 00:34:48
  */
@@ -27,9 +27,9 @@ static void set_LCD_DATA_PINS_as_outputs(void);
 static void set_LCD_DATA_PINS_as_inputs(void);
 static void set_LCD_DATA_PINS_state(uint8_t data);
 static uint8_t get_LCD_DATA_PINS_state(void);
-static void init_LCD_SIGNAL_PINS_as_outputs(void);
 static void LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void LCD_reset_SIG(enum lcd_sig LCD_SIG);
+// static void init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
@@ -38,7 +38,6 @@ static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
     set_LCD_DATA_PINS_as_inputs,
     set_LCD_DATA_PINS_state,
     get_LCD_DATA_PINS_state,
-    init_LCD_SIGNAL_PINS_as_outputs,
     LCD_set_SIG,
     LCD_reset_SIG,
     _delay_us,
@@ -52,11 +51,11 @@ const struct LCD_IO_driver_interface_struct *LCD_IO_driver_interface_get(void)
 
 static void init_LCD_data_and_SIG_pins(void)
 {
-    //enable BCKL of the LCD
+    // enable BCKL of the LCD
     LL_GPIO_SetOutputPin(LCD_BCKL_GPIO_Port, LCD_BCKL_Pin);
-    //enable CLK -> for this setup it's done by CUBE_IDE when generatig project files from it
-    //set_LCD_DATA_PINS_as_outputs -> for this setup it's done by CUBE_IDE when generatig project files from it
-    //init_LCD_SIGNAL_PINS_as_outputs -> for this setup it's done by CUBE_IDE when generatig project files from it
+    // enable CLK -> for this setup it's done by CUBE_IDE when generatig project files from it
+    // set_LCD_DATA_PINS_as_outputs -> for this setup it's done by CUBE_IDE when generatig project files from it
+    // init_LCD_SIGNAL_PINS_as_outputs -> for this setup it's done by CUBE_IDE when generatig project files from it
 }
 
 static void set_LCD_DATA_PINS_as_outputs(void)
@@ -112,26 +111,6 @@ static uint8_t get_LCD_DATA_PINS_state(void)
     return data;
 }
 
-static void init_LCD_SIGNAL_PINS_as_outputs(void)
-{
-#if USE_RW_PIN == 1
-    GPIO_InitStruct.Pin = LCD_RS_Pin | LCD_E_Pin | LCD_RW_Pin;
-    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-    LL_GPIO_Init(LCD_SIG_PORT, &GPIO_InitStruct);
-
-#else
-    GPIO_InitStruct.Pin = LCD_RS_Pin | LCD_E_Pin;
-    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
-    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
-    GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-    LL_GPIO_Init(LCD_SIG_PORT, &GPIO_InitStruct);
-#endif
-}
-
 static void LCD_set_SIG(enum lcd_sig LCD_SIG)
 {
     switch (LCD_SIG)
@@ -167,3 +146,23 @@ static void LCD_reset_SIG(enum lcd_sig LCD_SIG)
         break;
     }
 }
+
+// static void init_LCD_SIGNAL_PINS_as_outputs(void)
+// {
+// #if USE_RW_PIN == 1
+//     GPIO_InitStruct.Pin = LCD_RS_Pin | LCD_E_Pin | LCD_RW_Pin;
+//     GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+//     GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+//     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+//     GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+//     LL_GPIO_Init(LCD_SIG_PORT, &GPIO_InitStruct);
+
+// #else
+//     GPIO_InitStruct.Pin = LCD_RS_Pin | LCD_E_Pin;
+//     GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+//     GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+//     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+//     GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+//     LL_GPIO_Init(LCD_SIG_PORT, &GPIO_InitStruct);
+// #endif
+// }

--- a/test/lcd_hd44780/mock_LCD_IO_driver.c
+++ b/test/lcd_hd44780/mock_LCD_IO_driver.c
@@ -22,12 +22,12 @@ static void mock_set_LCD_DATA_PORT_as_outputs(void);
 static void mock_set_LCD_DATA_PORT_as_inputs(void);
 static void mock_set_LCD_DATA_PORT_state(uint8_t data);
 static uint8_t mock_get_LCD_DATA_PORT_state(void);
-static void mock_init_LCD_SIGNAL_PINS_as_outputs(void);
 static void mock_LCD_set_SIG(enum lcd_sig LCD_SIG);
 static void mock_LCD_reset_SIG(enum lcd_sig LCD_SIG);
 static uint8_t mock_get_pinmask(const enum lcd_sig *LCD_SIG);
 static void mock_delay_us(uint32_t delay_us);
 static void mock_dump_LCD_SIG_DATA_DELAY_state(uint32_t delay_us);
+static void mock_init_LCD_SIGNAL_PINS_as_outputs(void);
 
 /************LCD_IO_driver_interface implementation START**************/
 static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
@@ -36,7 +36,7 @@ static const struct LCD_IO_driver_interface_struct LCD_IO_driver = {
     mock_set_LCD_DATA_PORT_as_inputs,
     mock_set_LCD_DATA_PORT_state,
     mock_get_LCD_DATA_PORT_state,
-    mock_init_LCD_SIGNAL_PINS_as_outputs,
+    // mock_init_LCD_SIGNAL_PINS_as_outputs,
     mock_LCD_set_SIG,
     mock_LCD_reset_SIG,
     mock_delay_us,
@@ -77,16 +77,6 @@ static uint8_t mock_get_LCD_DATA_PORT_state(void)
     mock_LCD_DATA_PORT = 0x00;
     mock_dump_LCD_SIG_DATA_DELAY_state(0);
     return mock_LCD_DATA_PORT;
-}
-
-static void mock_init_LCD_SIGNAL_PINS_as_outputs(void)
-{
-#if USE_RW_PIN == ON
-    mock_LCD_SIG_PORT_DIRECTION = mock_LCD_E | mock_LCD_RS | mock_LCD_RW;
-    ;
-#else
-    mock_LCD_SIG_PORT_DIRECTION = mock_LCD_E | mock_LCD_RS;
-#endif
 }
 
 static void mock_LCD_set_SIG(enum lcd_sig LCD_SIG)
@@ -136,10 +126,21 @@ static void mock_dump_LCD_SIG_DATA_DELAY_state(uint32_t delay_us)
         dump_reg_pointer = 0;
 }
 
+static void mock_init_LCD_SIGNAL_PINS_as_outputs(void)
+{
+#if USE_RW_PIN == ON
+    mock_LCD_SIG_PORT_DIRECTION = mock_LCD_E | mock_LCD_RS | mock_LCD_RW;
+    ;
+#else
+    mock_LCD_SIG_PORT_DIRECTION = mock_LCD_E | mock_LCD_RS;
+#endif
+}
+
 uint8_t mock_get_lcd_init_state(void)
 {
     return (mock_LCD_SIG_PORT_DIRECTION << 4) | (mock_LCD_DATA_PORT_DIRECTION);
 }
+
 void mock_clear_LCD_Port_delay_dump_data(void)
 {
     for (uint16_t i = 0; i < BUF_SIZE; i++)


### PR DESCRIPTION
Remove from driver interface init of LCD signal pins. Signal and data pins should be initialize at the same time so ti schould be done by calling one callback from interface struct